### PR TITLE
Fix tag during IRMA server clone on container

### DIFF
--- a/Dockerfile.irmago.Dockerfile
+++ b/Dockerfile.irmago.Dockerfile
@@ -1,12 +1,11 @@
 FROM golang:1.14-alpine as irmago
 
-ARG VERSION='v0.7.0'
+ARG TAG_VERSION='v0.7.0'
 
 RUN apk add --no-cache bash git
 
-RUN git clone https://github.com/privacybydesign/irmago \
+RUN git clone --branch $TAG_VERSION https://github.com/privacybydesign/irmago \
     && cd irmago \
-    && git checkout $VERSION \
     && go install ./irma \
     && cd ../ \
     && rm -rf irmago

--- a/Dockerfile.irmago.Dockerfile
+++ b/Dockerfile.irmago.Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:1.14-alpine as irmago
 
+ARG VERSION='v0.7.0'
+
 RUN apk add --no-cache bash git
 
 RUN git clone https://github.com/privacybydesign/irmago \
     && cd irmago \
+    && git checkout $VERSION \
     && go install ./irma \
     && cd ../ \
     && rm -rf irmago

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ up:
 
 up-build:
 	docker-compose -f docker-compose.yml up --build --remove-orphans -d
-         
+
+up-build-nd:	## Get non-detached containers up with build
+	docker-compose -f docker-compose.yml up --build --remove-orphans
+
 up-nd:
 	docker-compose -f docker-compose.yml up --remove-orphans
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ up-build:
 up-nd:
 	docker-compose -f docker-compose.yml up --remove-orphans
 
-irmago-bash:
+irmago-bash:	## Exec bash into a running container
+	docker-compose -f docker-compose.yml exec -u $$UID:$$GID --rm irmago bash
+
+irmago-bash-run:	## Jump into a new container with bash
 	docker-compose -f docker-compose.yml run -u $$UID:$$GID --rm irmago bash
 
 irmago-bash-root:


### PR DESCRIPTION
- Fix IRMA setup into a tag to prevent errors with changes with master branch

Ex: current version of IRMA requires go-15, which we do not fully tested yet (both irma v0.8.0 and a container with go-15).
